### PR TITLE
Activation meta data not working

### DIFF
--- a/functions/lmfwc-license-functions.php
+++ b/functions/lmfwc-license-functions.php
@@ -447,8 +447,8 @@ function lmfwc_activate_license($licenseKey, $args)
         }
 
                 // Set metadata
-        if (isset($args['meta_data']) && is_array( $args['meta_data'] ) ) {
-            $activationParams['meta_data'] = $args['meta_data'];
+        if (isset($args['meta']) && is_array( $args['meta'] ) ) {
+            $activationParams['meta_data'] = wp_json_encode($args['meta']);
         }
 
                 // Store.

--- a/includes/Models/Resources/LicenseActivation.php
+++ b/includes/Models/Resources/LicenseActivation.php
@@ -48,7 +48,14 @@ class LicenseActivation extends AbstractResourceModel implements ModelInterface 
 		$this->source         = (int) $activation->source;
 		$this->ip_address     = $activation->ip_address;
 		$this->user_agent     = $activation->user_agent;
-		$this->meta_data      = $activation->meta_data ;
+        if ( !is_null( $activation->meta_data ) ) {
+            $this->meta_data = json_decode( $activation->meta_data, TRUE );
+            if(json_last_error() !== JSON_ERROR_NONE) {
+                $this->meta_data = $activation->meta_data;
+            }
+        } else {
+            $this->meta_data      = $activation->meta_data ;
+        }
 		$this->created_at     = $activation->created_at;
 		$this->updated_at     = $activation->updated_at;
 		$this->deactivated_at = $activation->deactivated_at;


### PR DESCRIPTION
Hi,

Activation meta data weren't working correctly as there is a typo in the variable name.
Moreover, meta data wasn't serialised / deserialised in the database.

I have made a fix that makes the meta data available in DB and server responses.

Please review the modifications as I am not a PHP developer.

Regards,
Jean-Marc